### PR TITLE
Integrate pfQuest to use quest links instead of titles

### DIFF
--- a/ChatMessage.lua
+++ b/ChatMessage.lua
@@ -30,3 +30,42 @@ function QPS.chatMessage.Send(title, text, finished)
         SendChatMessage(message, "PARTY")
     end
 end
+
+function QPS.chatMessage.SendLink(title, text, finished)
+    if not QuestProgressShareConfig or not QuestProgressShareConfig.enabled then return end
+    local message
+    if text and text ~= "" then
+        -- Color the message green if the objective is finished, red otherwise
+        if finished then
+            message = title .. " - " .. "|cff00ff00" .. text .. "|r"
+        else
+            message = title .. " - " .. "|cffff0000" .. text .. "|r"
+        end
+    else
+        message = title
+    end
+    -- Send to party
+    if QuestProgressShareConfig.sendInParty and (GetNumPartyMembers() > 0) then
+        if ChatThrottleLib and ChatThrottleLib.SendChatMessage then
+            ChatThrottleLib:SendChatMessage("NORMAL", "QPS", message, "PARTY")
+        else
+            SendChatMessage(message, "PARTY")
+        end
+    end
+    -- Send to self (show in local chat frame, not whisper)
+    if QuestProgressShareConfig.sendSelf then
+        if finished then
+            DEFAULT_CHAT_FRAME:AddMessage("[" .. UnitName("player") .. "]: " .. message, 0, 1, 0)
+        else
+            DEFAULT_CHAT_FRAME:AddMessage("[" .. UnitName("player") .. "]: " .. message, 1, 0, 0)
+        end
+    end
+    -- Send to public (SAY)
+    if QuestProgressShareConfig.sendPublic then
+        if ChatThrottleLib and ChatThrottleLib.SendChatMessage then
+            ChatThrottleLib:SendChatMessage("NORMAL", "QPS", message, "SAY")
+        else
+            SendChatMessage(message, "SAY")
+        end
+    end
+end

--- a/Core.lua
+++ b/Core.lua
@@ -1,9 +1,7 @@
+local QPS = QuestProgressShare
 -- Core.lua - Main logic for QuestProgressShare
 
-local QPS = QuestProgressShare -- main addon table
-
 QPS.suppressQuestLogUpdate = false -- prevent recursive or premature quest log updates
-
 local lastProgress = {} -- last known progress for each quest objective
 local completedQuestTitle = nil -- quest being turned in (for completion detection)
 local delayedQuestScanPending = false -- is a delayed scan scheduled
@@ -30,12 +28,123 @@ end
 
 delayedQuestScanFrame:SetScript("OnUpdate", DelayedQuestScanOnUpdate)
 
+local getQuestIDs = pfDatabase and pfDatabase.GetQuestIDs
+local pfDB = pfDB
+
+-- Helper to get a clickable quest link for chat (supports pfQuest, pfQuest-turtle, and locale-based tables)
+local function GetClickableQuestLink(questID, title)
+    local qid = tostring(questID)
+    local qid_num = tonumber(questID)
+    local locale = GetLocale and GetLocale() or "enUS"
+    local pfquests = pfDB and pfDB["quests"]
+    local pfdbs = {
+        { data = pfquests and pfquests["data"], loc = pfquests and pfquests["loc"] }, -- pfQuest legacy
+        { data = pfquests and pfquests["data-turtle"], loc = pfquests and pfquests[locale.."-turtle"] }, -- pfQuest-turtle
+        { data = pfquests and pfquests["data"], loc = pfquests and pfquests[locale] } -- pfQuest modern locale
+    }
+    local foundData, foundLoc, foundType
+    for i, db in ipairs(pfdbs) do
+        if db.data and db.loc then
+            local data = db.data[qid] or (qid_num and db.data[qid_num])
+            local loc = db.loc[qid] or (qid_num and db.loc[qid_num])
+            if data or loc then
+                foundData, foundLoc = data, loc
+                foundType = (i == 1 and "pfQuest-loc") or (i == 2 and "pfQuest-turtle") or (i == 3 and "pfQuest-locale")
+                break
+            end
+        end
+    end
+    local link
+    if foundData or foundLoc then
+        local level = foundData and foundData["lvl"] or 0
+        local name = foundLoc and foundLoc["T"] or (foundData and foundData["T"] or ("Quest "..qid))
+        local hex = "|cffffff00"
+        if pfUI and pfUI.api and pfUI.api.rgbhex and pfQuestCompat and pfQuestCompat.GetDifficultyColor then
+            hex = pfUI.api.rgbhex(pfQuestCompat.GetDifficultyColor(level))
+        end
+        link = hex .. "|Hquest:"..qid..":"..level.."|h["..name.."]|h|r"
+    elseif questID and tonumber(questID) then
+        local safeTitle = (type(title) == "string" and title) or ("Quest "..tostring(questID))
+        local cleanTitle = StringLib.Gsub(safeTitle, "|", "")
+        local hex = "|cffffff00"
+        if pfUI and pfUI.api and pfUI.api.rgbhex and pfQuestCompat and pfQuestCompat.GetDifficultyColor then
+            hex = pfUI.api.rgbhex(pfQuestCompat.GetDifficultyColor(0))
+        end
+        link = hex .. "|Hquest:"..tostring(questID)..":0|h["..cleanTitle.."]|h|r"
+    elseif type(title) == "string" and StringLib.Sub(title, 1, 8) == "|Hquest:" then
+        if StringLib.Sub(title, 1, 10) ~= "|cffffff00" then
+            link = "|cffffff00" .. title .. "|r"
+        else
+            link = title
+        end
+    elseif type(title) == "string" then
+        local safeTitle = StringLib.Gsub(title, "|", "")
+        link = "[" .. safeTitle .. "]"
+    else
+        link = qid
+    end
+    if type(link) == "string" and StringLib.Sub(link, 1, 8) == "|Hquest:" then
+        if StringLib.Sub(link, 1, 10) ~= "|cffffff00" then
+            link = "|cffffff00" .. link .. "|r"
+        end
+    end
+    return link
+end
+
+-- Helper: robust quest log index validation for pfQuest
+local function IsValidQuestLogIndex(index)
+    if type(index) ~= "number" or index < 1 or index > GetNumQuestLogEntries() then return false end
+    local title, _, _, isHeader = GetQuestLogTitle(index)
+    return (not isHeader) and title and title ~= ""
+end
+
+-- Cache for SafeGetQuestIDs results per scan
+local questIDCache = {}
+
+-- Helper: safe pfQuest GetQuestIDs call, with fallback
+local function SafeGetQuestIDs(index, title)
+    if questIDCache[index] ~= nil then
+        return questIDCache[index]
+    end
+    if not IsValidQuestLogIndex(index) then
+        questIDCache[index] = nil
+        return nil
+    end
+    if getQuestIDs then
+        local ok, ids = pcall(getQuestIDs, index)
+        if ok and ids and ids[1] then
+            questIDCache[index] = ids
+            return ids
+        else
+            local logTitle = GetQuestLogTitle(index)
+            if title and logTitle and logTitle == title and pfDB and pfDB["quests"] and pfDB["quests"]["loc"] then
+                for id, data in pairs(pfDB["quests"]["loc"]) do
+                    if data.T == title then
+                        questIDCache[index] = { tonumber(id) }
+                        return questIDCache[index]
+                    end
+                end
+            end
+        end
+    end
+    questIDCache[index] = nil
+    return nil
+end
+
 -- Dummy scan to populate lastProgress without sending messages
 local function DummyQuestProgressScan()
     for questIndex = 1, GetNumQuestLogEntries() do
         local title, _, _, isHeader, _, _, isComplete = GetQuestLogTitle(questIndex)
-        if not isHeader then
-            SelectQuestLogEntry(questIndex)
+        if not isHeader and title and IsValidQuestLogIndex(questIndex) then
+            if pfDB then
+                local ids = SafeGetQuestIDs(questIndex, title)
+                local questID = ids and ids[1] and tonumber(ids[1])
+                if questID then
+                    SelectQuestLogEntry(questIndex)
+                end
+            else
+                SelectQuestLogEntry(questIndex)
+            end
             local objectives = GetNumQuestLeaderBoards()
             -- Handle turn-in only quests (no objectives)
             if objectives == 0 and isComplete then
@@ -68,6 +177,56 @@ local function ExtractQuestTitleFromKey(key)
     return nil
 end
 
+-- Helper: find questID by title in pfQuest DB
+local function FindQuestIDByTitle(title)
+    if pfDB and pfDB.quests and pfDB.quests.loc then
+        for id, data in pairs(pfDB.quests.loc) do
+            if data.T == title then
+                return tonumber(id)
+            end
+        end
+    end
+    return nil
+end
+
+local function SendQuestMessage(title, text, finished, questIndex)
+    local questID = nil
+    if pfDB then
+        if questIndex then
+            local ids = SafeGetQuestIDs(questIndex, title)
+            if ids and ids[1] then
+                questID = ids[1]
+                -- Double-check: only send if the quest title for this questIndex matches pfQuest DB for this questID
+                local pfTitle = nil
+                if pfDB.quests and pfDB.quests.loc and pfDB.quests.loc[tostring(questID)] then
+                    pfTitle = pfDB.quests.loc[tostring(questID)].T
+                end
+                local logTitle = GetQuestLogTitle(questIndex)
+                if pfTitle and logTitle and pfTitle ~= logTitle then
+                    -- Mismatch: do not send
+                    return
+                end
+            else
+                questID = FindQuestIDByTitle(title)
+            end
+        else
+            questID = FindQuestIDByTitle(title)
+        end
+    elseif getQuestIDs then
+        local ids = getQuestIDs(title)
+        if ids and ids[1] then questID = ids[1] end
+    end
+    if pfDB and questID then
+        local link = GetClickableQuestLink(questID, title)
+        -- Accept any link containing |Hquest: as a clickable quest link
+        if link and type(link) == "string" and StringLib.Find(link, "|Hquest:") then
+            QPS.chatMessage.SendLink(link, text, finished)
+            return
+        end
+    end
+    QPS.chatMessage.Send(title, text, finished)
+end
+
 -- Handles quest progress tracking and event logic
 function OnEvent()
     -- Handles quest completion (quest turn-in window opened)
@@ -80,6 +239,9 @@ function OnEvent()
     -- Handles player login: initializes known quests and prints loaded message
     elseif event == "PLAYER_LOGIN" then
         if DEFAULT_CHAT_FRAME then DEFAULT_CHAT_FRAME:AddMessage("|cffb48affQuestProgressShare|r loaded.") end
+        if pfDB then
+            if DEFAULT_CHAT_FRAME then DEFAULT_CHAT_FRAME:AddMessage("|cffb48affQuestProgressShare: pfQuest integration enabled!|r") end
+        end
         if not QPS_SavedKnownQuests then QPS_SavedKnownQuests = {} end
         QPS.knownQuests = {}
         for k, v in pairs(QPS_SavedKnownQuests) do QPS.knownQuests[k] = v end
@@ -112,7 +274,7 @@ function OnEvent()
             end
         end)
         return
-        
+    
     -- Handles quest log updates: detects quest accept, completion, and progress
     elseif event == "QUEST_LOG_UPDATE" and QuestProgressShareConfig.enabled then
         -- Prevent recursive or premature updates
@@ -155,7 +317,7 @@ function OnEvent()
                 currentCount = currentCount + 1
                 if not previousQuests[title] then
                     foundNewQuest = true
-                    QPS.chatMessage.Send(title, "Quest accepted", false)
+                    SendQuestMessage(title, "Quest accepted", false)
                 end
             end
         end
@@ -174,7 +336,7 @@ function OnEvent()
                     local questKey = prevTitle .. "-COMPLETE"
                     if lastProgress[questKey] ~= "Quest completed" then
                         lastProgress[questKey] = "Quest completed"
-                        QPS.chatMessage.Send(prevTitle, "Quest completed", true)
+                        SendQuestMessage(prevTitle, "Quest completed", true)
                     end
                     completedQuestTitle = nil
                 end
@@ -192,64 +354,135 @@ function OnEvent()
         for k, v in pairs(currentQuests) do QPS_SavedKnownQuests[k] = v end
 
         -- Iterate through the quest log entries and announce progress/completion
-        for questIndex = 1, GetNumQuestLogEntries() do
-            local title, _, _, isHeader, _, _, isComplete = GetQuestLogTitle(questIndex)
-            if not isHeader then
-                SelectQuestLogEntry(questIndex)
-                local objectives = GetNumQuestLeaderBoards()
-                -- Handle turn-in only quests (no objectives)
-                if objectives == 0 and isComplete then
-                    local questKey = title .. "-COMPLETE"
-                    if lastProgress[questKey] ~= "Quest completed" then
-                        lastProgress[questKey] = "Quest completed"
-                        QPS.chatMessage.Send(title, "Quest completed", true)
+        if pfDB then
+            -- pfQuest enabled: only call SelectQuestLogEntry if we have a valid questID and valid index
+            for questIndex = 1, GetNumQuestLogEntries() do
+                local title, _, _, isHeader, _, _, isComplete = GetQuestLogTitle(questIndex)
+                if not isHeader and title and IsValidQuestLogIndex(questIndex) then
+                    local ids = SafeGetQuestIDs(questIndex, title)
+                    local questID = ids and ids[1] and tonumber(ids[1])
+                    if questID then
+                        SelectQuestLogEntry(questIndex)
                     end
-                end
-                local completedObjectives = 0
-                local totalObjectives = objectives
-                -- Check each quest objective for progress
-                for i = 1, objectives do
-                    local text, objType, finished = GetQuestLogLeaderBoard(i)
-                    local questKey = title .. "-" .. i
-                    local isMeaningless = false
-                    if type(text) ~= "string" then
-                        isMeaningless = true
-                    else
-                        local current, total = StringLib.SafeExtractNumbers(text, QPS_Debug)
-                        if not current or tonumber(current) == 0 then
-                            isMeaningless = true
-                        end
-                    end
-                    if isComplete then
+                    local objectives = GetNumQuestLeaderBoards()
+                    -- Handle turn-in only quests (no objectives)
+                    if objectives == 0 and isComplete then
+                        local questKey = title .. "-COMPLETE"
                         if lastProgress[questKey] ~= "Quest completed" then
                             lastProgress[questKey] = "Quest completed"
-                        end
-                    else
-                        if (lastProgress[questKey] == nil or lastProgress[questKey] == "") then
-                            if not isMeaningless and (QuestProgressShareConfig.sendStartingQuests or (type(text) == "string" and StringLib.Sub(text, 1, 3) ~= " : ")) then
-                                lastProgress[questKey] = text
-                                -- Only send if not first scan, or if changed since last session
-                                if (not firstProgressScan) or (QPS_SavedProgress[questKey] ~= text) then
-                                    if (finished or not QuestProgressShareConfig.sendOnlyFinished) and (not completedQuestTitle or completedQuestTitle ~= title) then
-                                        QPS.chatMessage.Send(title, text, finished)
-                                    end
-                                end
-                            end
-                        elseif lastProgress[questKey] ~= text then
-                            lastProgress[questKey] = text
-                            if not isMeaningless and (finished or not QuestProgressShareConfig.sendOnlyFinished) and (not completedQuestTitle or completedQuestTitle ~= title) then
-                                QPS.chatMessage.Send(title, text, finished)
-                            end
+                            SendQuestMessage(title, "Quest completed", true, questIndex)
                         end
                     end
-                    if finished then completedObjectives = completedObjectives + 1 end
+                    local completedObjectives = 0
+                    local totalObjectives = objectives
+                    -- Check each quest objective for progress
+                    for i = 1, objectives do
+                        local text, objType, finished = GetQuestLogLeaderBoard(i)
+                        local questKey = title .. "-" .. i
+                        local isMeaningless = false
+                        if type(text) ~= "string" then
+                            isMeaningless = true
+                        else
+                            local current, total = StringLib.SafeExtractNumbers(text, QPS_Debug)
+                            if not current or tonumber(current) == 0 then
+                                isMeaningless = true
+                            end
+                        end
+                        if isComplete then
+                            if lastProgress[questKey] ~= "Quest completed" then
+                                lastProgress[questKey] = "Quest completed"
+                            end
+                        else
+                            if (lastProgress[questKey] == nil or lastProgress[questKey] == "") then
+                                if not isMeaningless and (QuestProgressShareConfig.sendStartingQuests or (type(text) == "string" and StringLib.Sub(text, 1, 3) ~= " : ")) then
+                                    lastProgress[questKey] = text
+                                    -- Only send if not first scan, or if changed since last session
+                                    if (not firstProgressScan) or (QPS_SavedProgress[questKey] ~= text) then
+                                        if (finished or not QuestProgressShareConfig.sendOnlyFinished) and (not completedQuestTitle or completedQuestTitle ~= title) then
+                                            SendQuestMessage(title, text, finished, questIndex)
+                                        end
+                                    end
+                                end
+                            elseif lastProgress[questKey] ~= text then
+                                lastProgress[questKey] = text
+                                if not isMeaningless and (finished or not QuestProgressShareConfig.sendOnlyFinished) and (not completedQuestTitle or completedQuestTitle ~= title) then
+                                    SendQuestMessage(title, text, finished, questIndex)
+                                end
+                            end
+                        end
+                        if finished then completedObjectives = completedObjectives + 1 end
+                    end
+                    -- Send 'Quest completed' for all quest types (with or without objectives)
+                    if objectives > 0 then
+                        local questKey = title .. "-COMPLETE"
+                        if isComplete and lastProgress[questKey] ~= "Quest completed" then
+                            lastProgress[questKey] = "Quest completed"
+                            SendQuestMessage(title, "Quest completed", true, questIndex)
+                        end
+                    end
                 end
-                -- Send 'Quest completed' for all quest types (with or without objectives)
-                if objectives > 0 then
-                    local questKey = title .. "-COMPLETE"
-                    if isComplete and lastProgress[questKey] ~= "Quest completed" then
-                        lastProgress[questKey] = "Quest completed"
-                        QPS.chatMessage.Send(title, "Quest completed", true)
+            end
+        else
+            -- pfQuest not enabled: original logic
+            for questIndex = 1, GetNumQuestLogEntries() do
+                local title, _, _, isHeader, _, _, isComplete = GetQuestLogTitle(questIndex)
+                if not isHeader then
+                    SelectQuestLogEntry(questIndex)
+                    local objectives = GetNumQuestLeaderBoards()
+                    -- Handle turn-in only quests (no objectives)
+                    if objectives == 0 and isComplete then
+                        local questKey = title .. "-COMPLETE"
+                        if lastProgress[questKey] ~= "Quest completed" then
+                            lastProgress[questKey] = "Quest completed"
+                            SendQuestMessage(title, "Quest completed", true)
+                        end
+                    end
+                    local completedObjectives = 0
+                    local totalObjectives = objectives
+                    -- Check each quest objective for progress
+                    for i = 1, objectives do
+                        local text, objType, finished = GetQuestLogLeaderBoard(i)
+                        local questKey = title .. "-" .. i
+                        local isMeaningless = false
+                        if type(text) ~= "string" then
+                            isMeaningless = true
+                        else
+                            local current, total = StringLib.SafeExtractNumbers(text, QPS_Debug)
+                            if not current or tonumber(current) == 0 then
+                                isMeaningless = true
+                            end
+                        end
+                        if isComplete then
+                            if lastProgress[questKey] ~= "Quest completed" then
+                                lastProgress[questKey] = "Quest completed"
+                            end
+                        else
+                            if (lastProgress[questKey] == nil or lastProgress[questKey] == "") then
+                                if not isMeaningless and (QuestProgressShareConfig.sendStartingQuests or (type(text) == "string" and StringLib.Sub(text, 1, 3) ~= " : ")) then
+                                    lastProgress[questKey] = text
+                                    -- Only send if not first scan, or if changed since last session
+                                    if (not firstProgressScan) or (QPS_SavedProgress[questKey] ~= text) then
+                                        if (finished or not QuestProgressShareConfig.sendOnlyFinished) and (not completedQuestTitle or completedQuestTitle ~= title) then
+                                            SendQuestMessage(title, text, finished)
+                                        end
+                                    end
+                                end
+                            elseif lastProgress[questKey] ~= text then
+                                lastProgress[questKey] = text
+                                if not isMeaningless and (finished or not QuestProgressShareConfig.sendOnlyFinished) and (not completedQuestTitle or completedQuestTitle ~= title) then
+                                    SendQuestMessage(title, text, finished)
+                                end
+                            end
+                        end
+                        if finished then completedObjectives = completedObjectives + 1 end
+                    end
+                    -- Send 'Quest completed' for all quest types (with or without objectives)
+                    if objectives > 0 then
+                        local questKey = title .. "-COMPLETE"
+                        if isComplete and lastProgress[questKey] ~= "Quest completed" then
+                            lastProgress[questKey] = "Quest completed"
+                            SendQuestMessage(title, "Quest completed", true)
+                        end
                     end
                 end
             end
@@ -296,3 +529,4 @@ QPS:RegisterEvent("ADDON_LOADED")
 QPS:RegisterEvent("PLAYER_ENTERING_WORLD")
 QPS:RegisterEvent("QUEST_COMPLETE")
 QPS:SetScript("OnEvent", OnEvent)
+

--- a/QuestProgressShare.toc
+++ b/QuestProgressShare.toc
@@ -2,10 +2,11 @@
 ## Title: Quest Progress Share
 ## Notes: Sends a message to the party when you complete a quest.
 ## Author: GraveD89, Dreambjorn
-## Version: 1.2.0
+## Version: 1.2.1
 ## SavedVariablesPerCharacter: QPS_SavedKnownQuests
 ## SavedVariablesPerCharacter: QPS_SavedProgress
 ## SavedVariablesPerCharacter: QuestProgressShareConfig
+## SavedVariablesPerCharacter: QPS_SavedLoadCount
 
 Main.lua
 libs\ChatThrottleLib.lua

--- a/QuestProgressShare.toc
+++ b/QuestProgressShare.toc
@@ -2,13 +2,14 @@
 ## Title: Quest Progress Share
 ## Notes: Sends a message to the party when you complete a quest.
 ## Author: GraveD89, Dreambjorn
-## Version: 1.1.7
+## Version: 1.2.0
 ## SavedVariablesPerCharacter: QPS_SavedKnownQuests
 ## SavedVariablesPerCharacter: QPS_SavedProgress
 ## SavedVariablesPerCharacter: QuestProgressShareConfig
 
-StringLib.lua
 Main.lua
+libs\ChatThrottleLib.lua
+libs\StringLib.lua
 Config.lua
 ChatMessage.lua
 Core.lua

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ When the first quest update occurs after installing the addon, all current quest
 
 ## Changelog
 
+### 1.2.1
+- Prevent spam of "Quest accepted" messages on initial addon load
+
 ### 1.2.0
 - Add pfQuest integration to send quest links instead of plain titles
 - Use ChatThrottleLib to prevent addon compatibility issues

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ When the first quest update occurs after installing the addon, all current quest
 
 ## Changelog
 
+### 1.2.0
+- Add pfQuest integration to send quest links instead of plain titles
+- Use ChatThrottleLib to prevent addon compatibility issues
+- Reorganize addon file structure
+Note: If pfQuest is not installed, the addon will still function using its legacy plain title messages.
+
 ### 1.1.7
 - Add a custom string library to handle string.match (or similar) safely
 - Implement saved quest progress using saved character variables

--- a/libs/ChatThrottleLib.lua
+++ b/libs/ChatThrottleLib.lua
@@ -1,0 +1,502 @@
+--
+-- ChatThrottleLib by Mikk
+--
+-- Manages AddOn chat output to keep player from getting kicked off.
+--
+-- ChatThrottleLib.SendChatMessage/.SendAddonMessage functions that accept
+-- a Priority ("BULK", "NORMAL", "ALERT") as well as prefix for SendChatMessage.
+--
+-- Priorities get an equal share of available bandwidth when fully loaded.
+-- Communication channels are separated on extension+chattype+destination and
+-- get round-robinned. (Destination only matters for whispers and channels,
+-- obviously)
+--
+-- Will install hooks for SendChatMessage and SendAdd[Oo]nMessage to measure
+-- bandwidth bypassing the library and use less bandwidth itself.
+--
+--
+-- Fully embeddable library. Just copy this file into your addon directory,
+-- add it to the .toc, and it's done.
+--
+-- Can run as a standalone addon also, but, really, just embed it! :-)
+--
+
+--
+-- ChangeLog and notes for this version:
+-- There is no historic CTL version 14 and this would supersede all other Vanilla era
+-- versions (<=13) while also not stepping on private server TBC versions (15+)
+--
+-- Modifications for this version are simply to throttle raw chat lines per second and
+-- have nothing to do with the bytes sent.  Chat to CHANNEL, RAID, etc all count toward
+-- this limit.  Otherwise, this is the same as version 13 as it relates to throttling
+-- raw bytes sent.  To be clear, this update doesn't further throttle raw add-on messages.
+--
+local CTL_VERSION = 14
+
+local MAX_CPS = 800			  -- 2000 seems to be safe if NOTHING ELSE is happening. let's call it 800.
+local MSG_OVERHEAD = 40		-- Guesstimate overhead for sending a message; source+dest+chattype+protocolstuff
+
+local BURST = 4000				-- WoW's server buffer seems to be about 32KB. 8KB should be safe, but seen disconnects on _some_ servers. Using 4KB now.
+
+local MIN_FPS = 20				-- Reduce output CPS to half (and don't burst) if FPS drops below this value
+
+-- Turtle seems to allow > 6 lines per second in some situations; but for pure spam throughput, a value of 6 here seems to be the limit.
+-- Due to timing issues, setting this to 5.75 seems to allow the most throughput without any accidental soft bans.
+local TURTLE_MAX_CHAT_LINES_PER_SECOND = 5
+
+if(ChatThrottleLib and ChatThrottleLib.version>=CTL_VERSION) then
+	-- There's already a newer (or same) version loaded. Buh-bye.
+	return;
+end
+
+
+
+if(not ChatThrottleLib) then
+	ChatThrottleLib = {}
+end
+
+local ChatThrottleLib = ChatThrottleLib
+local strlen = strlen
+local setmetatable = setmetatable
+local getn = getn
+local tremove = tremove
+local tinsert = tinsert
+local tostring = tostring
+local GetTime = GetTime
+local format = format
+
+ChatThrottleLib.version=CTL_VERSION;
+
+
+-----------------------------------------------------------------------
+-- Double-linked ring implementation
+
+local Ring = {}
+local RingMeta = { __index=Ring }
+
+function Ring:New()
+	local ret = {}
+	setmetatable(ret, RingMeta)
+	return ret;
+end
+
+function Ring:Add(obj)	-- Append at the "far end" of the ring (aka just before the current position)
+	if(self.pos) then
+		obj.prev = self.pos.prev;
+		obj.prev.next = obj;
+		obj.next = self.pos;
+		obj.next.prev = obj;
+	else
+		obj.next = obj;
+		obj.prev = obj;
+		self.pos = obj;
+	end
+end
+
+function Ring:Remove(obj)
+	obj.next.prev = obj.prev;
+	obj.prev.next = obj.next;
+	if(self.pos == obj) then
+		self.pos = obj.next;
+		if(self.pos == obj) then
+			self.pos = nil;
+		end
+	end
+end
+
+
+
+-----------------------------------------------------------------------
+-- Recycling bin for pipes (kept in a linked list because that's
+-- how they're worked with in the rotating rings; just reusing members)
+
+ChatThrottleLib.PipeBin = { count=0 }
+
+function ChatThrottleLib.PipeBin:Put(pipe)
+	for i=getn(pipe),1,-1 do
+		tremove(pipe, i);
+	end
+	pipe.prev = nil;
+	pipe.next = self.list;
+	self.list = pipe;
+	self.count = self.count+1;
+end
+
+function ChatThrottleLib.PipeBin:Get()
+	if(self.list) then
+		local ret = self.list;
+		self.list = ret.next;
+		ret.next=nil;
+		self.count = self.count - 1;
+		return ret;
+	end
+	return {};
+end
+
+function ChatThrottleLib.PipeBin:Tidy()
+	if(self.count < 25) then
+		return;
+	end
+
+	if(self.count > 100) then
+		n=self.count-90;
+	else
+		n=10;
+	end
+	for i=2,n do
+		self.list = self.list.next;
+	end
+	local delme = self.list;
+	self.list = self.list.next;
+	delme.next = nil;
+end
+
+
+
+
+-----------------------------------------------------------------------
+-- Recycling bin for messages
+
+ChatThrottleLib.MsgBin = {}
+
+function ChatThrottleLib.MsgBin:Put(msg)
+	msg.text = nil;
+	tinsert(self, msg);
+end
+
+function ChatThrottleLib.MsgBin:Get()
+	local ret = tremove(self, getn(self));
+	if(ret) then return ret; end
+	return {};
+end
+
+function ChatThrottleLib.MsgBin:Tidy()
+	if(getn(self)<50) then
+		return;
+	end
+	if(getn(self)>150) then	 -- "can't happen" but ...
+		for n=getn(self),120,-1 do
+			tremove(self,n);
+		end
+	else
+		for n=getn(self),getn(self)-20,-1 do
+			tremove(self,n);
+		end
+	end
+end
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib:Init
+-- Initialize queues, set up frame for OnUpdate, etc
+
+
+function ChatThrottleLib:Init()
+
+	-- Set up queues
+	if(not self.Prio) then
+		self.Prio = {}
+		self.Prio["ALERT"] = { ByName={}, Ring = Ring:New(), avail=0 };
+		self.Prio["NORMAL"] = { ByName={}, Ring = Ring:New(), avail=0 };
+		self.Prio["BULK"] = { ByName={}, Ring = Ring:New(), avail=0 };
+	end
+
+	-- v4: total send counters per priority
+	for _,Prio in pairs(self.Prio) do
+		Prio.nTotalSent = Prio.nTotalSent or 0;
+	end
+
+	self.avail = self.avail or 0;							-- v5
+	self.nTotalSent = self.nTotalSent or 0;		-- v5
+
+
+	-- Set up a frame to get OnUpdate events
+	if(not self.Frame) then
+		self.Frame = CreateFrame("Frame");
+		self.Frame:Hide();
+	end
+	self.Frame.Show = self.Frame.Show; -- cache for speed
+	self.Frame.Hide = self.Frame.Hide; -- cache for speed
+	self.Frame:SetScript("OnUpdate", self.OnUpdate);
+	self.Frame:SetScript("OnEvent", self.OnEvent);	-- v11: Monitor P_E_W so we can throttle hard for a few seconds
+	self.Frame:RegisterEvent("PLAYER_ENTERING_WORLD");
+	self.OnUpdateDelay=0;
+  self.TurtleChatLinesAvailable=TURTLE_MAX_CHAT_LINES_PER_SECOND;
+	self.LastAvailUpdate=GetTime();
+	self.HardThrottlingBeginTime=GetTime();	-- v11: Throttle hard for a few seconds after startup
+
+	-- Hook SendChatMessage and SendAddonMessage so we can measure unpiped traffic and avoid overloads (v7)
+	if(not self.ORIG_SendChatMessage) then
+		--SendChatMessage
+		self.ORIG_SendChatMessage = SendChatMessage;
+		SendChatMessage = function(a1,a2,a3,a4) return ChatThrottleLib.Hook_SendChatMessage(a1,a2,a3,a4); end
+		--SendAdd[Oo]nMessage
+		if(SendAddonMessage or SendAddOnMessage) then -- v10: don't pretend like it doesn't exist if it doesn't!
+			self.ORIG_SendAddonMessage = SendAddonMessage or SendAddOnMessage;
+			SendAddonMessage = function(a1,a2,a3) return ChatThrottleLib.Hook_SendAddonMessage(a1,a2,a3); end
+			if(SendAddOnMessage) then		-- in case Slouken changes his mind...
+				SendAddOnMessage = SendAddonMessage;
+			end
+		end
+	end
+	self.nBypass = 0;
+end
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib.Hook_SendChatMessage / .Hook_SendAddonMessage
+function ChatThrottleLib.Hook_SendChatMessage(text, chattype, language, destination)
+	local self = ChatThrottleLib;
+	local size = strlen(tostring(text or "")) + strlen(tostring(chattype or "")) + strlen(tostring(destination or "")) + 40;
+	self.avail = self.avail - size;
+	self.nBypass = self.nBypass + size;
+  self.TurtleSendChat()
+	return self.ORIG_SendChatMessage(text, chattype, language, destination);
+end
+function ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype)
+	local self = ChatThrottleLib;
+	local size = strlen(tostring(text or "")) + strlen(tostring(chattype or "")) + strlen(tostring(prefix or "")) + 40;
+	self.avail = self.avail - size;
+	self.nBypass = self.nBypass + size;
+	return self.ORIG_SendAddonMessage(prefix, text, chattype);
+end
+
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib:UpdateAvail
+-- Update self.avail with how much bandwidth is currently available
+
+function ChatThrottleLib:UpdateAvail()
+	local now = GetTime();
+	local newavail = MAX_CPS * (now-self.LastAvailUpdate);
+
+	if(now - self.HardThrottlingBeginTime < 5) then
+		-- First 5 seconds after startup/zoning: VERY hard clamping to avoid irritating the server rate limiter, it seems very cranky then
+		self.avail = min(self.avail + (newavail*0.1), MAX_CPS*0.5);
+	elseif(GetFramerate()<MIN_FPS) then		-- GetFrameRate call takes ~0.002 secs
+		newavail = newavail * 0.5;
+		self.avail = min(MAX_CPS, self.avail + newavail);
+		self.bChoking = true;		-- just for stats
+	else
+		self.avail = min(BURST, self.avail + newavail);
+		self.bChoking = false;
+	end
+
+	self.avail = max(self.avail, 0-(MAX_CPS*2));	-- Can go negative when someone is eating bandwidth past the lib. but we refuse to stay silent for more than 2 seconds; if they can do it, we can.
+	self.LastAvailUpdate = now;
+
+	return self.avail;
+end
+
+
+-----------------------------------------------------------------------
+-- Despooling logic
+function ChatThrottleLib.TurtleSendChat()
+	self = ChatThrottleLib;
+  self.TurtleChatLinesAvailable = self.TurtleChatLinesAvailable - 1
+  -- Showing the frame will start to build back the available buffer and re-hide when max lines are available
+  self.Frame:Show();
+end
+
+function ChatThrottleLib.IsTurtleSendChatReady()
+	self = ChatThrottleLib;
+  if self.TurtleChatLinesAvailable > 1 then
+    return true
+  end
+  -- print("Chat Throttled")
+  return false
+end
+
+function ChatThrottleLib:Despool(Prio)
+	local ring = Prio.Ring;
+	while(ring.pos and Prio.avail>ring.pos[1].nSize and self.IsTurtleSendChatReady()) do
+		local msg = tremove(Prio.Ring.pos, 1);
+		if(not Prio.Ring.pos[1]) then
+			local pipe = Prio.Ring.pos;
+			Prio.Ring:Remove(pipe);
+			Prio.ByName[pipe.name] = nil;
+			self.PipeBin:Put(pipe);
+		else
+			Prio.Ring.pos = Prio.Ring.pos.next;
+		end
+		Prio.avail = Prio.avail - msg.nSize;
+		msg.f(msg[1], msg[2], msg[3], msg[4]);
+    if msg.type == "chat" then self.TurtleSendChat() end
+		Prio.nTotalSent = Prio.nTotalSent + msg.nSize;
+		self.MsgBin:Put(msg);
+	end
+end
+
+
+function ChatThrottleLib.OnEvent()
+	-- v11: We know that the rate limiter is touchy after login. Assume that it's touch after zoning, too.
+	self = ChatThrottleLib;
+	if(event == "PLAYER_ENTERING_WORLD") then
+		self.HardThrottlingBeginTime=GetTime();	-- Throttle hard for a few seconds after zoning
+		self.avail = 0;
+	end
+end
+
+
+function ChatThrottleLib.OnUpdate()
+	self = ChatThrottleLib;
+
+	self.OnUpdateDelay = self.OnUpdateDelay + arg1;
+	if(self.OnUpdateDelay < 0.08) then
+		return;
+	end
+  if self.TurtleChatLinesAvailable < TURTLE_MAX_CHAT_LINES_PER_SECOND then
+    self.TurtleChatLinesAvailable = math.min(self.TurtleChatLinesAvailable + self.OnUpdateDelay * TURTLE_MAX_CHAT_LINES_PER_SECOND, TURTLE_MAX_CHAT_LINES_PER_SECOND)
+  end
+	self.OnUpdateDelay = 0;
+
+	self:UpdateAvail();
+
+	if(self.avail<0) then
+		return; -- argh. some bastard is spewing stuff past the lib. just bail early to save cpu.
+	end
+
+	-- See how many of or priorities have queued messages
+	local n=0;
+	for prioname,Prio in pairs(self.Prio) do
+		if(Prio.Ring.pos or Prio.avail<0) then
+			n=n+1;
+		end
+	end
+
+	-- Anything queued still?
+	if(n<1 and self.TurtleChatLinesAvailable >= TURTLE_MAX_CHAT_LINES_PER_SECOND) then
+		-- Nope. Move spillover bandwidth to global availability gauge and clear self.bQueueing
+		for prioname,Prio in pairs(self.Prio) do
+			self.avail = self.avail + Prio.avail;
+			Prio.avail = 0;
+		end
+		self.bQueueing = false;
+		self.Frame:Hide();
+		return;
+	end
+
+	-- There's stuff queued. Hand out available bandwidth to priorities as needed and despool their queues
+	local avail= self.avail/n;
+	self.avail = 0;
+
+	for prioname,Prio in pairs(self.Prio) do
+		if(Prio.Ring.pos or Prio.avail<0) then
+			Prio.avail = Prio.avail + avail;
+			if(Prio.Ring.pos and Prio.avail>Prio.Ring.pos[1].nSize) then
+				self:Despool(Prio);
+			end
+		end
+	end
+
+	-- Expire recycled tables if needed
+	self.MsgBin:Tidy();
+	self.PipeBin:Tidy();
+end
+
+
+
+
+-----------------------------------------------------------------------
+-- Spooling logic
+
+
+function ChatThrottleLib:Enqueue(prioname, pipename, msg)
+	local Prio = self.Prio[prioname];
+	local pipe = Prio.ByName[pipename];
+	if(not pipe) then
+		self.Frame:Show();
+		pipe = self.PipeBin:Get();
+		pipe.name = pipename;
+		Prio.ByName[pipename] = pipe;
+		Prio.Ring:Add(pipe);
+	end
+
+	tinsert(pipe, msg);
+
+	self.bQueueing = true;
+end
+
+
+
+function ChatThrottleLib:SendChatMessage(prio, prefix, text, chattype, language, destination)
+	if(not (self and prio and text and self.Prio[prio] ) ) then
+		error('Usage: ChatThrottleLib:SendChatMessage("{BULK||NORMAL||ALERT}", "prefix" or nil, "text"[, "chattype"[, "language"[, "destination"]]]', 2);
+	end
+
+	prefix = prefix or tostring(this);		-- each frame gets its own queue if prefix is not given
+
+	local nSize = strlen(text) + MSG_OVERHEAD;
+
+	-- Check if there's room in the global available bandwidth gauge to send directly
+	if(not self.bQueueing and nSize < self:UpdateAvail() and self.IsTurtleSendChatReady()) then
+		self.avail = self.avail - nSize;
+		self.ORIG_SendChatMessage(text, chattype, language, destination);
+    self.TurtleSendChat()
+		self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize;
+		return;
+	end
+
+	-- Message needs to be queued
+	msg=self.MsgBin:Get();
+	msg.f=self.ORIG_SendChatMessage
+  msg.type="chat";
+	msg[1]=text;
+	msg[2]=chattype or "SAY";
+	msg[3]=language;
+	msg[4]=destination;
+	msg.n = 4
+	msg.nSize = nSize;
+
+	self:Enqueue(prio, format("%s/%s/%s", prefix, chattype, destination or ""), msg);
+end
+
+
+function ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype)
+	if(not (self and prio and prefix and text and chattype and self.Prio[prio] ) ) then
+		error('Usage: ChatThrottleLib:SendAddonMessage("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype")', 0);
+	end
+
+	local nSize = strlen(prefix) + 1 + strlen(text) + MSG_OVERHEAD;
+
+	-- Check if there's room in the global available bandwidth gauge to send directly
+	if(not self.bQueueing and nSize < self:UpdateAvail()) then
+		self.avail = self.avail - nSize;
+		self.ORIG_SendAddonMessage(prefix, text, chattype);
+		self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize;
+		return;
+	end
+
+	-- Message needs to be queued
+	msg=self.MsgBin:Get();
+	msg.f=self.ORIG_SendAddonMessage;
+  msg.type="addon";
+	msg[1]=prefix;
+	msg[2]=text;
+	msg[3]=chattype;
+	msg.n = 3
+	msg.nSize = nSize;
+
+	self:Enqueue(prio, format("%s/%s", prefix, chattype), msg);
+end
+
+
+
+
+-----------------------------------------------------------------------
+-- Get the ball rolling!
+
+ChatThrottleLib:Init();
+
+--[[ WoWBench debugging snippet
+if(WOWB_VER) then
+	local function SayTimer()
+		print("SAY: "..GetTime().." "..arg1);
+	end
+	ChatThrottleLib.Frame:SetScript("OnEvent", SayTimer);
+	ChatThrottleLib.Frame:RegisterEvent("CHAT_MSG_SAY");
+end
+]]
+
+


### PR DESCRIPTION
- Add pfQuest integration to send quest links instead of plain titles
- Use ChatThrottleLib to prevent addon compatibility issues
- Reorganize addon file structure
- Prevent spam of "Quest accepted" messages on initial addon load by silently storing all current quests and progress to the Saved Character Variables