### PR TITLE
Add world object/mob tooltip integration for party quest progress

### DIFF
--- a/ChatMessage.lua
+++ b/ChatMessage.lua
@@ -4,33 +4,42 @@
 local QPS = QuestProgressShare
 QPS.chatMessage = {}
 
+-- Helper function to determine if an objective is complete
+local function IsObjectiveComplete(text, finished, objectiveFinished)
+    if objectiveFinished == true then
+        return true
+    end
+    
+    local current, required = StringLib.SafeExtractNumbers(text or "")
+    if current and required then
+        current = tonumber(current)
+        required = tonumber(required)
+        if current and required and current >= required then
+            return true
+        end
+    end
+    
+    -- If finished is true (whole quest complete), always complete
+    if finished then 
+        return true 
+    end
+    
+    return false
+end
+
 -- Sends a quest progress message to chat, party, and/or addon channels based on config.
 function QPS.chatMessage.Send(title, text, finished, objectiveIndex, objectiveFinished)
-    LogDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] QPS.chatMessage.Send called: title=" .. tostring(title) .. ", text=" .. tostring(text) .. ", finished=" .. tostring(finished) .. ", objectiveIndex=" .. tostring(objectiveIndex) .. ", objectiveFinished=" .. tostring(objectiveFinished))
+    LogVerboseDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] QPS.chatMessage.Send called: title=" .. tostring(title) .. ", text=" .. tostring(text) .. ", finished=" .. tostring(finished) .. ", objectiveIndex=" .. tostring(objectiveIndex) .. ", objectiveFinished=" .. tostring(objectiveFinished))
     if QuestProgressShareConfig then
-        LogDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] sendSelf=" .. tostring(QuestProgressShareConfig.sendSelf) .. ", sendPublic=" .. tostring(QuestProgressShareConfig.sendPublic) .. ", sendInParty=" .. tostring(QuestProgressShareConfig.sendInParty))
+        LogVerboseDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] sendSelf=" .. tostring(QuestProgressShareConfig.sendSelf) .. ", sendPublic=" .. tostring(QuestProgressShareConfig.sendPublic) .. ", sendInParty=" .. tostring(QuestProgressShareConfig.sendInParty))
     else
         LogDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] QuestProgressShareConfig is nil!")
     end
 
     local message = title .. " - " .. text
 
-    -- Determine color: green if objective is complete or over-complete, red otherwise
-    local isObjectiveComplete = false
-    if objectiveFinished == true then
-        isObjectiveComplete = true
-    else
-        local current, required = StringLib.SafeExtractNumbers(text or "")
-        if current and required then
-            current = tonumber(current)
-            required = tonumber(required)
-            if current and required and current >= required then
-                isObjectiveComplete = true
-            end
-        end
-        -- If finished is true (whole quest complete), always green
-        if finished then isObjectiveComplete = true end
-    end
+    -- Determine color using helper function
+    local isObjectiveComplete = IsObjectiveComplete(text, finished, objectiveFinished)
 
     -- Send the message to the default chatframe
     if (QuestProgressShareConfig.sendSelf) then
@@ -61,28 +70,15 @@ end
 
 -- Sends a quest progress message with a clickable link to chat, party, and/or addon channels based on config.
 function QPS.chatMessage.SendLink(title, text, finished, objectiveIndex, objectiveFinished)
-    LogDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] QPS.chatMessage.SendLink called: title=" .. tostring(title) .. ", text=" .. tostring(text) .. ", finished=" .. tostring(finished) .. ", objectiveIndex=" .. tostring(objectiveIndex) .. ", objectiveFinished=" .. tostring(objectiveFinished))
+    LogVerboseDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] QPS.chatMessage.SendLink called: title=" .. tostring(title) .. ", text=" .. tostring(text) .. ", finished=" .. tostring(finished) .. ", objectiveIndex=" .. tostring(objectiveIndex) .. ", objectiveFinished=" .. tostring(objectiveFinished))
     if not QuestProgressShareConfig or QuestProgressShareConfig.enabled ~= 1 then
         LogDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] SendLink: config missing or disabled! enabled=" .. tostring(QuestProgressShareConfig and QuestProgressShareConfig.enabled))
         return
     end
-    LogDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] sendSelf=" .. tostring(QuestProgressShareConfig.sendSelf) .. ", sendPublic=" .. tostring(QuestProgressShareConfig.sendPublic) .. ", sendInParty=" .. tostring(QuestProgressShareConfig.sendInParty))
+    LogVerboseDebugMessage(QPS_CoreDebugLog, "[QPS-DEBUG] sendSelf=" .. tostring(QuestProgressShareConfig.sendSelf) .. ", sendPublic=" .. tostring(QuestProgressShareConfig.sendPublic) .. ", sendInParty=" .. tostring(QuestProgressShareConfig.sendInParty))
 
     local message
-    local isObjectiveComplete = false
-    if objectiveFinished == true then
-        isObjectiveComplete = true
-    else
-        local current, required = StringLib.SafeExtractNumbers(text or "")
-        if current and required then
-            current = tonumber(current)
-            required = tonumber(required)
-            if current and required and current >= required then
-                isObjectiveComplete = true
-            end
-        end
-        if finished then isObjectiveComplete = true end
-    end
+    local isObjectiveComplete = IsObjectiveComplete(text, finished, objectiveFinished)
 
     if text and text ~= "" then
         if isObjectiveComplete then

--- a/Config.lua
+++ b/Config.lua
@@ -35,6 +35,9 @@ function QPS.config.SetDefaultConfigValues()
     if QuestProgressShareConfig.debugEnabled == nil then
         QuestProgressShareConfig.debugEnabled = false
     end
+    if QuestProgressShareConfig.verboseDebugEnabled == nil then
+        QuestProgressShareConfig.verboseDebugEnabled = false
+    end
     if QuestProgressShareConfig.sendAbandoned == nil then
         QuestProgressShareConfig.sendAbandoned = false
     end
@@ -43,15 +46,24 @@ end
 -- Create the config frame
 QPS.configFrame = CreateFrame("Frame", "QuestProgressShareConfigFrame", UIParent)
 QPS.configFrame:SetWidth(300)
-QPS.configFrame:SetHeight(340)
+QPS.configFrame:SetHeight(350)
 QPS.configFrame:SetPoint("CENTER", 0, 0)
-QPS.configFrame:SetBackdrop({
-    bgFile = "Interface/Tooltips/UI-Tooltip-Background",
-    edgeFile = "Interface/Tooltips/UI-Tooltip-Border",
-    tile = true, tileSize = 16, edgeSize = 16,
-    insets = { left = 4, right = 4, top = 4, bottom = 4 }
-})
-QPS.configFrame:SetBackdropColor(0, 0, 0, 1)
+
+-- Apply pfUI styling if pfUI is available, otherwise use default styling
+if pfUI and pfUI.api and pfUI.api.CreateBackdrop then
+    -- Use pfUI styling
+    pfUI.api.CreateBackdrop(QPS.configFrame, nil, true, 0.8)
+else
+    -- Use default WoW styling
+    QPS.configFrame:SetBackdrop({
+        bgFile = "Interface/Tooltips/UI-Tooltip-Background",
+        edgeFile = "Interface/Tooltips/UI-Tooltip-Border",
+        tile = true, tileSize = 16, edgeSize = 16,
+        insets = { left = 4, right = 4, top = 4, bottom = 4 }
+    })
+    QPS.configFrame:SetBackdropColor(0, 0, 0, 1)
+end
+
 QPS.configFrame:SetMovable(true)
 QPS.configFrame:EnableMouse(true)
 QPS.configFrame:Hide()
@@ -166,11 +178,39 @@ checkboxDebugEnabled:SetPoint("TOPLEFT", 20, -250)
 checkboxDebugEnabled:SetChecked(QuestProgressShareConfig.debugEnabled)
 checkboxDebugEnabled:SetScript("OnClick", function()
     QuestProgressShareConfig.debugEnabled = checkboxDebugEnabled:GetChecked()
+    -- Update verbose debug checkbox state when debug is toggled
+    UpdateVerboseDebugState()
 end)
 
 local labelDebugEnabled = QPS.configFrame:CreateFontString("QuestProgressShareConfigDebugEnabledLabel", "OVERLAY", "GameFontNormal")
 labelDebugEnabled:SetPoint("LEFT", checkboxDebugEnabled, "RIGHT", 10, 0)
 labelDebugEnabled:SetText("Enable debug logging")
+
+-- Checkbox for verbose debug output
+local checkboxVerboseDebugEnabled = CreateFrame("CheckButton", "QuestProgressShareConfigVerboseDebugEnabledCheckbox", QPS.configFrame, "UICheckButtonTemplate")
+checkboxVerboseDebugEnabled:SetPoint("TOPLEFT", 40, -280)
+checkboxVerboseDebugEnabled:SetChecked(QuestProgressShareConfig.verboseDebugEnabled)
+checkboxVerboseDebugEnabled:SetScript("OnClick", function()
+    QuestProgressShareConfig.verboseDebugEnabled = checkboxVerboseDebugEnabled:GetChecked()
+end)
+
+local labelVerboseDebugEnabled = QPS.configFrame:CreateFontString("QuestProgressShareConfigVerboseDebugEnabledLabel", "OVERLAY", "GameFontNormal")
+labelVerboseDebugEnabled:SetPoint("LEFT", checkboxVerboseDebugEnabled, "RIGHT", 10, 0)
+labelVerboseDebugEnabled:SetText("Enable verbose debug logging")
+
+-- Function to update verbose debug checkbox state based on debug enabled
+function UpdateVerboseDebugState()
+    local isDebugEnabled = QuestProgressShareConfig.debugEnabled
+    if isDebugEnabled then
+        checkboxVerboseDebugEnabled:Enable()
+        labelVerboseDebugEnabled:SetTextColor(1, 0.82, 0) -- Yellow text when enabled and debug is on (same as other labels)
+    else
+        checkboxVerboseDebugEnabled:Disable()
+        checkboxVerboseDebugEnabled:SetChecked(false)
+        QuestProgressShareConfig.verboseDebugEnabled = false
+        labelVerboseDebugEnabled:SetTextColor(0.5, 0.5, 0.5) -- Gray text when disabled
+    end
+end
 
 -- Update the config options when the frame is shown
 QPS.configFrame:SetScript("OnShow", function()
@@ -187,14 +227,23 @@ function UpdateConfigFrame()
     checkboxSendStartingQuests:SetChecked(QuestProgressShareConfig.sendStartingQuests)
     checkboxSendAbandoned:SetChecked(QuestProgressShareConfig.sendAbandoned)
     checkboxDebugEnabled:SetChecked(QuestProgressShareConfig.debugEnabled)
+    checkboxVerboseDebugEnabled:SetChecked(QuestProgressShareConfig.verboseDebugEnabled)
+    -- Update verbose debug state based on debug enabled
+    UpdateVerboseDebugState()
 end
 
 -- Creates and configures the Close button for the config frame.
 local closeButton = CreateFrame("Button", nil, QPS.configFrame, "UIPanelButtonTemplate")
 closeButton:SetWidth(80)
 closeButton:SetHeight(22)
-closeButton:SetPoint("BOTTOM", 0, 20)
+closeButton:SetPoint("BOTTOM", 0, 10)
 closeButton:SetText("Close")
+
+-- Apply pfUI styling to the close button if pfUI is available
+if pfUI and pfUI.api and pfUI.api.SkinButton then
+    pfUI.api.SkinButton(closeButton)
+end
+
 closeButton:SetScript("OnClick", function()    
     QPS.configFrame:Hide()
     -- ReloadUI()

--- a/QuestProgressShare.toc
+++ b/QuestProgressShare.toc
@@ -2,8 +2,8 @@
 ## Title: Quest Progress Share
 ## Notes: Sends a message to the party when you complete a quest.
 ## Author: GraveD89, Dreambjorn
-## Version: 1.4.5
-## OptionalDeps: pfQuest
+## Version: 1.5.0
+## OptionalDeps: pfQuest, pfUI
 ## SavedVariables: QPS_DebugLog, QPS_CoreDebugLog, QPS_EventDebugLog, QPS_ProgressDebugLog, QPS_SyncDebugLog, QPS_ConfigDebugLog
 ## SavedVariablesPerCharacter: QPS_SavedKnownQuests, QPS_SavedProgress, QuestProgressShareConfig, QPS_SavedLoadCount
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # QuestProgressShare
-This AddOn sends quest progress to other players.
-If you are playing with friends and want to share your quest progress, this AddOn is for you.  
+Automatically syncs quest progress with your party in real time. Designed for smoother and more coordinated group questing without the need for manual updates or chat messages. 
   
 If you encounter any issues or errors, please report them in the [bugtracker](https://github.com/Dreambjorn/QuestProgressShare/issues).
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,31 @@ If you have any feature requests, please let me know [here](https://github.com/D
 - `/qps` to open the settings window
 
 ## Features
-- Share quest progress
+- **Share quest progress**
     - with party members
     - with yourself
     - with local chat
-- Share all quest progress or only finished quests
-- Share quest links instead of plain titles (only if pfQuest is enabled)
+- **Share all quest progress or only finished quests**
+- **Share quest links instead of plain titles** *(only if pfQuest is enabled)*
+- **Party progress tooltips** - View party member quest progress by hovering over:
+    - Quest log entries - Display party member progress for the same quest when hovering over quest log titles
+    - Tracker entries - Show party member progress in pfQuest tracker tooltips when available
+    - World objects/mobs - View party progress for quest-related entities when hovering over them in the world
+- **pfQuest integration** - Enhanced tooltip experience when pfQuest is available, with automatic fallback
 
 ## Changelog
+
+### 1.5.0
+- Add world object/mob tooltip integration to display party quest progress when hovering over quest-related entities
+- Deduplicate and unify tooltip logic by creating helper functions for class colors and objective processing
+- Unify world object/mob tooltip integration to always use GameTooltip for consistent party progress display
+- Preserve pfQuest integration where required while eliminating unnecessary pfQuest checks in world object/mob tooltips
+- Improve message coloring consistency by using centralized IsObjectiveComplete() helper function
+- Enhance code maintainability by removing redundant logic between quest log/tracker tooltips and world object/mob tooltip systems
+- Update tooltip comments to reflect unified approach with helper functions
+- Refactor debug logging system to support two-tier debugging with normal and verbose modes
+- Add Verbose Debug configuration option that can only be enabled when main debug logging is active
+- Optimize debug output by moving highly detailed logs (table dumps, per-objective traces, string parsing internals) to verbose-only mode
 
 ### 1.4.5
 - Fix objective progress coloring by adding per-objective completion status tracking

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ If you have any feature requests, please let me know [here](https://github.com/D
     - Quest log entries - Display party member progress for the same quest when hovering over quest log titles
     - Tracker entries - Show party member progress in pfQuest tracker tooltips when available
     - World objects/mobs - View party progress for quest-related entities when hovering over them in the world
-- **pfQuest integration** - Enhanced tooltip experience when pfQuest is available, with automatic fallback
 
 ## Changelog
 

--- a/libs/StringLib.lua
+++ b/libs/StringLib.lua
@@ -240,7 +240,7 @@ function StringLib.HasNumberSlashNumber(s)
                 if k <= len then
                     local c3 = StringLib.Byte(s, k)
                     if c3 and c3 >= 48 and c3 <= 57 then
-                        LogDebugMessage("[QPS-DEBUG] HasNumberSlashNumber: matched in '"..tostring(s).."'")
+                        LogVerboseDebugMessage(QPS_DebugLog, "[QPS-DEBUG] HasNumberSlashNumber: matched in '"..tostring(s).."'")
                         return true
                     end
                 end
@@ -248,7 +248,7 @@ function StringLib.HasNumberSlashNumber(s)
         end
         i = i + 1
     end
-    LogDebugMessage("[QPS-DEBUG] HasNumberSlashNumber: no match in '"..tostring(s).."'")
+    LogVerboseDebugMessage(QPS_DebugLog, "[QPS-DEBUG] HasNumberSlashNumber: no match in '"..tostring(s).."'")
     return false
 end
 
@@ -280,7 +280,7 @@ function StringLib.ExtractQuestAndObjIdx(key)
     -- Extracts the quest name and objective index from a key formatted as 'questName-idx'. Returns quest name and objective index as strings, or nil, nil if not valid.
     -- Returns quest name and objective index as strings, or nil, nil if not valid.
     if type(key) ~= "string" then
-        LogDebugMessage("[QPS-DEBUG] ExtractQuestAndObjIdx: key is not a string: " .. tostring(key))
+        LogVerboseDebugMessage(QPS_DebugLog, "[QPS-DEBUG] ExtractQuestAndObjIdx: key is not a string: " .. tostring(key))
         return nil, nil
     end
     local len = StringLib.Len(key)
@@ -293,7 +293,7 @@ function StringLib.ExtractQuestAndObjIdx(key)
         end
     end
     if not dashPos then
-        LogDebugMessage("[QPS-DEBUG] ExtractQuestAndObjIdx: no dash found in key: " .. tostring(key))
+        LogVerboseDebugMessage(QPS_DebugLog, "[QPS-DEBUG] ExtractQuestAndObjIdx: no dash found in key: " .. tostring(key))
         return nil, nil
     end
     local quest = StringLib.Sub(key, 1, dashPos - 1)
@@ -305,9 +305,9 @@ function StringLib.ExtractQuestAndObjIdx(key)
         if b < 48 or b > 57 then isDigits = false break end
     end
     if not isDigits then
-        LogDebugMessage("[QPS-WARN] ExtractQuestAndObjIdx: objIdx is not all digits: " .. tostring(objIdxStr) .. " in key: " .. tostring(key))
+        LogVerboseDebugMessage(QPS_DebugLog, "[QPS-WARN] ExtractQuestAndObjIdx: objIdx is not all digits: " .. tostring(objIdxStr) .. " in key: " .. tostring(key))
         return nil, nil
     end
-    LogDebugMessage(string.format("[QPS-DEBUG] ExtractQuestAndObjIdx: key='%s', quest='%s', objIdx='%s'", tostring(key), tostring(quest), tostring(objIdxStr)))
+    LogVerboseDebugMessage(QPS_DebugLog, string.format("[QPS-DEBUG] ExtractQuestAndObjIdx: key='%s', quest='%s', objIdx='%s'", tostring(key), tostring(quest), tostring(objIdxStr)))
     return quest, objIdxStr
 end

--- a/util/QuestStringHelpers.lua
+++ b/util/QuestStringHelpers.lua
@@ -57,9 +57,7 @@ function SanitizeAddonMessage(title, text)
     local safeText = ExtractProgress(text)
     if StringLib.Find(safeTitle, "|") then safeTitle = StringLib.Gsub(safeTitle, "|", "") end
     if StringLib.Find(safeText, "|") then safeText = StringLib.Gsub(safeText, "|", "") end
-    if QPS_DebugLog then
-        table.insert(QPS_DebugLog, "SanitizeAddonMessage: title_before='"..tostring(title).."' title_after='"..tostring(safeTitle).."' text_before='"..tostring(text).."' text_after='"..tostring(safeText).."'")
-    end
+    LogVerboseDebugMessage(QPS_DebugLog, "SanitizeAddonMessage: title_before='"..tostring(title).."' title_after='"..tostring(safeTitle).."' text_before='"..tostring(text).."' text_after='"..tostring(safeText).."'")
     return safeTitle, safeText
 end
 


### PR DESCRIPTION
- Add world object/mob tooltip integration to display party quest progress when hovering over quest-related entities
- Deduplicate and unify tooltip logic by creating helper functions for class colors and objective processing
- Unify world object/mob tooltip integration to always use GameTooltip for consistent party progress display
- Preserve pfQuest integration where required while eliminating unnecessary pfQuest checks in world object/mob tooltips
- Improve message coloring consistency by using centralized IsObjectiveComplete() helper function
- Enhance code maintainability by removing redundant logic between quest log/tracker tooltips and world object/mob tooltip systems
- Update tooltip comments to reflect unified approach with helper functions
- Refactor debug logging system to support two-tier debugging with normal and verbose modes
- Add Verbose Debug configuration option that can only be enabled when main debug logging is active
- Optimize debug output by moving highly detailed logs (table dumps, per-objective traces, string parsing internals) to verbose-only mode